### PR TITLE
[feat] Add wrapper support for pNFT transfers

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -28,3 +28,8 @@ address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
 [[test.validator.clone]]
 url = "https://api.mainnet-beta.solana.com"
 address = "auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg"
+
+# pNFT Ruleset Program - Metaplex Foundation Rule Set (created by Brandon Tulsi of Metaplex, default rule set, all pass-through rules)
+[[test.validator.clone]]
+url = "https://api.mainnet-beta.solana.com"
+address = "eBJLFYPxJmMGKuFwpDWkzxZeUrad92kZRC5BJLpzyT9"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -15,3 +15,16 @@ wallet = "/Users/noahgundotra/.config/solana/id.json"
 
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+
+[test.validator]
+url = "https://api.mainnet-beta.solana.com"
+
+# Token Metadata Program
+[[test.validator.clone]]
+url = "https://api.mainnet-beta.solana.com"
+address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+
+# pNFT Ruleset Program
+[[test.validator.clone]]
+url = "https://api.mainnet-beta.solana.com"
+address = "auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpl-token-auth-rules"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24dcb2b0ec0e9246f6f035e0336ba3359c21f6928dfd90281999e2c8e8ab53eb"
+dependencies = [
+ "borsh",
+ "mpl-token-metadata-context-derive",
+ "num-derive",
+ "num-traits",
+ "rmp-serde",
+ "serde",
+ "shank",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "thiserror",
+]
+
+[[package]]
+name = "mpl-token-metadata"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e674db8846d4a603454ce9c93233dd8d503d62f2afe1b9e6486ce81e431f89"
+dependencies = [
+ "arrayref",
+ "borsh",
+ "mpl-token-auth-rules",
+ "mpl-token-metadata-context-derive",
+ "mpl-utils",
+ "num-derive",
+ "num-traits",
+ "shank",
+ "solana-program",
+ "spl-associated-token-account",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
+name = "mpl-token-metadata-context-derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12989bc45715b0ee91944855130131479f9c772e198a910c3eb0ea327d5bffc3"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "mpl-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc48e64c50dba956acb46eec86d6968ef0401ef37031426da479f1f2b592066"
+dependencies = [
+ "arrayref",
+ "borsh",
+ "solana-program",
+ "spl-token",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,6 +1544,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "rmp"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,6 +1737,40 @@ checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
  "digest 0.10.6",
  "keccak",
+]
+
+[[package]]
+name = "shank"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63e565b5e95ad88ab38f312e89444c749360641c509ef2de0093b49f55974a5"
+dependencies = [
+ "shank_macro",
+]
+
+[[package]]
+name = "shank_macro"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63927d22a1e8b74bda98cc6e151fcdf178b7abb0dc6c4f81e0bbf5ffe2fc4ec8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "shank_macro_impl",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "shank_macro_impl"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce03403df682f80f4dc1efafa87a4d0cb89b03726d0565e6364bdca5b9a441"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2082,6 +2198,8 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "mpl-token-auth-rules",
+ "mpl-token-metadata",
  "token-interface",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,12 +693,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -717,11 +741,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
 ]
@@ -1176,6 +1211,8 @@ dependencies = [
  "mpl-utils",
  "num-derive",
  "num-traits",
+ "serde",
+ "serde_with 1.14.0",
  "shank",
  "solana-program",
  "spl-associated-token-account",
@@ -1673,12 +1710,34 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85456ffac572dc8826334164f2fb6fb40a7c766aebe195a2a21ee69ee2885ecf"
 dependencies = [
  "serde",
- "serde_with_macros",
+ "serde_with_macros 2.3.1",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1687,7 +1746,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cbcd6104f8a4ab6af7f6be2a0da6be86b9de3c401f6e86bb856ab2af739232f"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1946,7 +2005,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "serde_with",
+ "serde_with 2.3.1",
  "sha2 0.10.6",
  "sha3 0.10.6",
  "solana-frozen-abi",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     },
     "dependencies": {
         "@coral-xyz/anchor": "^0.27.0",
+        "@metaplex-foundation/beet": "^0.7.1",
+        "@metaplex-foundation/mpl-token-auth-rules": "^1.2.0",
+        "@metaplex-foundation/mpl-token-metadata": "^2.10.0",
+        "@msgpack/msgpack": "^3.0.0-beta2",
         "@solana/spl-token": "^0.3.7"
     },
     "devDependencies": {

--- a/programs/token-wrapper/Cargo.toml
+++ b/programs/token-wrapper/Cargo.toml
@@ -18,4 +18,6 @@ default = []
 [dependencies]
 anchor-lang = "0.27.0"
 anchor-spl = "0.27.0"
+mpl-token-auth-rules = { version = "1.3.0", features = ["no-entrypoint"] }
+mpl-token-metadata = { version="1.10.0", features=["no-entrypoint"] }
 token-interface = { path = "../../token-interface" }

--- a/programs/token-wrapper/Cargo.toml
+++ b/programs/token-wrapper/Cargo.toml
@@ -19,5 +19,5 @@ default = []
 anchor-lang = "0.27.0"
 anchor-spl = "0.27.0"
 mpl-token-auth-rules = { version = "1.3.0", features = ["no-entrypoint"] }
-mpl-token-metadata = { version="1.10.0", features=["no-entrypoint"] }
+mpl-token-metadata = { version="1.10.0", features=["no-entrypoint", "serde-feature"] }
 token-interface = { path = "../../token-interface" }

--- a/tests/itoken-poc.ts
+++ b/tests/itoken-poc.ts
@@ -26,7 +26,7 @@ import {
 } from "@solana/web3.js";
 import { base64 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 
-import { create, mintPnft, transfer } from "./pnft";
+import { DEFAULT_PASS_RULESET, create, mintPnft } from "./pnft";
 
 async function resolveRemainingAccounts<I extends anchor.Idl>(
   program: anchor.Program<I>,
@@ -189,11 +189,16 @@ describe("itoken-poc", () => {
         metadata: metadataKey,
         mintKp,
         tx,
-      } = await create(wrapper.provider.connection, wallet, {
-        name: "test",
-        symbol: "test",
-        uri: "test",
-      });
+      } = await create(
+        wrapper.provider.connection,
+        wallet,
+        DEFAULT_PASS_RULESET,
+        {
+          name: "test",
+          symbol: "test",
+          uri: "test",
+        }
+      );
 
       pnftMetadata = metadataKey;
 

--- a/tests/itoken-poc.ts
+++ b/tests/itoken-poc.ts
@@ -221,7 +221,6 @@ describe("itoken-poc", () => {
         })
         .instruction();
       let keys = await resolveRemainingAccounts(wrapper, [ix]);
-      console.log("keys", keys);
 
       const txId = await wrapper.methods
         .transfer(new anchor.BN(1))

--- a/tests/pnft.ts
+++ b/tests/pnft.ts
@@ -1,0 +1,271 @@
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  SYSVAR_INSTRUCTIONS_PUBKEY,
+  LAMPORTS_PER_SOL,
+  sendAndConfirmTransaction,
+  ComputeBudgetProgram,
+  SystemProgram,
+} from "@solana/web3.js";
+import {
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
+import {
+  AssetData,
+  CreateInstructionAccounts,
+  CreateInstructionArgs,
+  Metadata,
+  MintInstructionAccounts,
+  MintInstructionArgs,
+  PROGRAM_ID,
+  Payload,
+  TokenStandard,
+  TransferInstructionAccounts,
+  TransferInstructionArgs,
+  createCreateInstruction,
+  createMintInstruction,
+  createTransferInstruction,
+} from "@metaplex-foundation/mpl-token-metadata";
+import { PROGRAM_ID as TOKEN_AUTH_RULES_ID } from "@metaplex-foundation/mpl-token-auth-rules";
+import { bignum } from "@metaplex-foundation/beet";
+
+type CreateDigitalAssetArgs = {
+  name: string;
+  symbol: string;
+  uri: string;
+};
+
+export const DEFAULT_PASS_RULESET = new PublicKey(
+  "eBJLFYPxJmMGKuFwpDWkzxZeUrad92kZRC5BJLpzyT9"
+);
+
+export async function create(
+  connection: Connection,
+  payer: PublicKey,
+  ruleSet: PublicKey | null,
+  digitalAssetArgs: CreateDigitalAssetArgs
+) {
+  const { name, symbol, uri } = digitalAssetArgs;
+
+  const mintKp = Keypair.generate();
+  const mint = mintKp.publicKey;
+
+  const [metadata] = PublicKey.findProgramAddressSync(
+    [Buffer.from("metadata"), PROGRAM_ID.toBuffer(), mint.toBuffer()],
+    PROGRAM_ID
+  );
+  const [masterEdition] = PublicKey.findProgramAddressSync(
+    [
+      Buffer.from("metadata"),
+      PROGRAM_ID.toBuffer(),
+      mint.toBuffer(),
+      Buffer.from("edition"),
+    ],
+    PROGRAM_ID
+  );
+
+  // Create the initial asset and ensure it was created successfully
+  const assetData: AssetData = {
+    name,
+    symbol,
+    uri,
+    sellerFeeBasisPoints: 0,
+    creators: [
+      {
+        address: payer,
+        share: 100,
+        verified: false,
+      },
+    ],
+    primarySaleHappened: false,
+    isMutable: true,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+    // collection: collection ? { key: collection, verified: false } : null,
+    collection: null,
+    uses: null,
+    collectionDetails: null,
+    ruleSet,
+  };
+
+  const accounts: CreateInstructionAccounts = {
+    metadata,
+    masterEdition,
+    mint: mint,
+    authority: payer,
+    payer: payer,
+    splTokenProgram: TOKEN_PROGRAM_ID,
+    sysvarInstructions: SYSVAR_INSTRUCTIONS_PUBKEY,
+    updateAuthority: payer,
+  };
+
+  const args: CreateInstructionArgs = {
+    createArgs: {
+      __kind: "V1",
+      assetData,
+      decimals: 0,
+      printSupply: { __kind: "Zero" },
+    },
+  };
+
+  const tx = new Transaction();
+  let createIx = createCreateInstruction(accounts, args);
+  for (let i = 0; i < createIx.keys.length; i++) {
+    if (createIx.keys[i].pubkey.toBase58() === mint.toBase58()) {
+      createIx.keys[i].isSigner = true;
+      createIx.keys[i].isWritable = true;
+    }
+  }
+  tx.add(createIx);
+  tx.feePayer = payer;
+  tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+
+  return { tx, mintKp, metadata };
+}
+
+export async function transfer(
+  connection: Connection,
+  amount: number,
+  metadata: PublicKey,
+  owner: PublicKey,
+  to: PublicKey,
+  authority: PublicKey
+) {
+  let meta = await Metadata.fromAccountAddress(
+    connection,
+    metadata,
+    "confirmed"
+  );
+  let authorizationRules = meta.programmableConfig.ruleSet;
+
+  let token = getAssociatedTokenAddressSync(meta.mint, owner);
+  let destination = getAssociatedTokenAddressSync(meta.mint, to);
+
+  const [masterEdition] = PublicKey.findProgramAddressSync(
+    [
+      Buffer.from("metadata"),
+      PROGRAM_ID.toBuffer(),
+      meta.mint.toBuffer(),
+      Buffer.from("edition"),
+    ],
+    PROGRAM_ID
+  );
+
+  const transferAcccounts: TransferInstructionAccounts = {
+    authority: authority,
+    tokenOwner: new PublicKey(owner),
+    token,
+    metadata: new PublicKey(metadata),
+    mint: meta.mint,
+    edition: masterEdition,
+    destinationOwner: to,
+    destination,
+    payer: authority,
+    splTokenProgram: TOKEN_PROGRAM_ID,
+    splAtaProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+    systemProgram: SystemProgram.programId,
+    sysvarInstructions: SYSVAR_INSTRUCTIONS_PUBKEY,
+    authorizationRules,
+    authorizationRulesProgram: TOKEN_AUTH_RULES_ID,
+    ownerTokenRecord: findTokenRecordPda(meta.mint, token),
+    destinationTokenRecord: findTokenRecordPda(meta.mint, destination),
+  };
+
+  const args = {
+    __kind: "V1",
+    amount: amount as bignum,
+    authorizationData: null,
+  };
+  const transferArgs: TransferInstructionArgs = {
+    transferArgs: args as any,
+  };
+  const transferIx = createTransferInstruction(transferAcccounts, transferArgs);
+  const modifyComputeUnits = ComputeBudgetProgram.setComputeUnitLimit({
+    units: 400_000,
+  });
+
+  const tx = new Transaction();
+  tx.add(modifyComputeUnits).add(transferIx);
+  return tx;
+}
+
+export async function mintPnft(
+  connection: Connection,
+  metadata: PublicKey,
+  owner: PublicKey,
+  amount: number
+) {
+  const meta = await Metadata.fromAccountAddress(
+    connection,
+    metadata,
+    "confirmed"
+  );
+  const authConfig = meta.programmableConfig;
+  const [masterEdition] = PublicKey.findProgramAddressSync(
+    [
+      Buffer.from("metadata"),
+      PROGRAM_ID.toBuffer(),
+      meta.mint.toBuffer(),
+      Buffer.from("edition"),
+    ],
+    PROGRAM_ID
+  );
+
+  let token = getAssociatedTokenAddressSync(meta.mint, owner);
+  let tokenRecord = findTokenRecordPda(meta.mint, token);
+  const mintAcccounts: MintInstructionAccounts = {
+    token,
+    tokenOwner: owner,
+    metadata,
+    masterEdition,
+    tokenRecord,
+    mint: meta.mint,
+    payer: owner,
+    authority: owner,
+    sysvarInstructions: SYSVAR_INSTRUCTIONS_PUBKEY,
+    splAtaProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+    splTokenProgram: TOKEN_PROGRAM_ID,
+    authorizationRules: authConfig ? authConfig.ruleSet : null,
+    authorizationRulesProgram: TOKEN_AUTH_RULES_ID,
+  };
+
+  const payload: Payload = {
+    map: new Map(),
+  };
+
+  let authorizationData = {
+    payload,
+  };
+
+  const mintArgs: MintInstructionArgs = {
+    mintArgs: {
+      __kind: "V1",
+      amount,
+      authorizationData,
+    },
+  };
+
+  const mintIx = createMintInstruction(mintAcccounts, mintArgs);
+  const tx = new Transaction();
+  tx.add(mintIx);
+  return tx;
+}
+
+export function findTokenRecordPda(
+  mint: PublicKey,
+  token: PublicKey
+): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [
+      Buffer.from("metadata"),
+      PROGRAM_ID.toBuffer(),
+      mint.toBuffer(),
+      Buffer.from("token_record"),
+      token.toBuffer(),
+    ],
+    PROGRAM_ID
+  )[0];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,59 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
+"@metaplex-foundation/beet-solana@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/beet-solana/-/beet-solana-0.4.0.tgz#52891e78674aaa54e0031f1bca5bfbc40de12e8d"
+  integrity sha512-B1L94N3ZGMo53b0uOSoznbuM5GBNJ8LwSeznxBxJ+OThvfHQ4B5oMUqb+0zdLRfkKGS7Q6tpHK9P+QK0j3w2cQ==
+  dependencies:
+    "@metaplex-foundation/beet" ">=0.1.0"
+    "@solana/web3.js" "^1.56.2"
+    bs58 "^5.0.0"
+    debug "^4.3.4"
+
+"@metaplex-foundation/beet@>=0.1.0", "@metaplex-foundation/beet@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/beet/-/beet-0.7.1.tgz#0975314211643f87b5f6f3e584fa31abcf4c612c"
+  integrity sha512-hNCEnS2WyCiYyko82rwuISsBY3KYpe828ubsd2ckeqZr7tl0WVLivGkoyA/qdiaaHEBGdGl71OpfWa2rqL3DiA==
+  dependencies:
+    ansicolors "^0.3.2"
+    bn.js "^5.2.0"
+    debug "^4.3.3"
+
+"@metaplex-foundation/cusper@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/cusper/-/cusper-0.0.2.tgz#dc2032a452d6c269e25f016aa4dd63600e2af975"
+  integrity sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA==
+
+"@metaplex-foundation/mpl-token-auth-rules@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/mpl-token-auth-rules/-/mpl-token-auth-rules-1.2.0.tgz#31e8154e7039c2c184c9dda1f61eb107b4adcc81"
+  integrity sha512-UkfBkYEdenefIKxE2L15j9ZHUJYYRQoDqNqDawh5DxdemmVV3GLnIlbMilr/HLXyXb2eMAOUdl5XgZFwKYN5EA==
+  dependencies:
+    "@metaplex-foundation/beet" "^0.7.1"
+    "@metaplex-foundation/beet-solana" "^0.4.0"
+    "@metaplex-foundation/cusper" "^0.0.2"
+    "@solana/spl-token" "^0.3.6"
+    "@solana/web3.js" "^1.66.2"
+
+"@metaplex-foundation/mpl-token-metadata@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-2.10.0.tgz#87785d305a23bd68075919ce995b3160408ddedc"
+  integrity sha512-oCAzs4Wl7m+8ZeW6VVX8NDNbMBNDbH0vbysBmY8Eh9Moq0inSjm2dtojzQGEFTpVSAEFEzinRLXtkeWqiiI3ug==
+  dependencies:
+    "@metaplex-foundation/beet" "^0.7.1"
+    "@metaplex-foundation/beet-solana" "^0.4.0"
+    "@metaplex-foundation/cusper" "^0.0.2"
+    "@solana/spl-token" "^0.3.6"
+    "@solana/web3.js" "^1.66.2"
+    bn.js "^5.2.0"
+    debug "^4.3.4"
+
+"@msgpack/msgpack@^3.0.0-beta2":
+  version "3.0.0-beta2"
+  resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-3.0.0-beta2.tgz#5bccee30f84df220b33905e3d8249ba96deca0b7"
+  integrity sha512-y+l1PNV0XDyY8sM3YtuMLK5vE3/hkfId+Do8pLo/OPxfxuFAUwcGz3oiiUuV46/aBpwTzZ+mRWVMtlSKbradhw==
+
 "@noble/ed25519@^1.7.0":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.3.tgz#57e1677bf6885354b466c38e2b620c62f45a7123"
@@ -70,7 +123,7 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/spl-token@^0.3.7":
+"@solana/spl-token@^0.3.6", "@solana/spl-token@^0.3.7":
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.3.7.tgz#6f027f9ad8e841f792c32e50920d9d2e714fc8da"
   integrity sha512-bKGxWTtIw6VDdCBngjtsGlKGLSmiu/8ghSt/IOYJV24BsymRbgq7r12GToeetpxmPaZYLddKwAz7+EwprLfkfg==
@@ -79,7 +132,7 @@
     "@solana/buffer-layout-utils" "^0.2.0"
     buffer "^6.0.3"
 
-"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.68.0":
+"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.66.2", "@solana/web3.js@^1.68.0":
   version "1.75.0"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.75.0.tgz#824c6f78865007bca758ca18f268d6f7363b42e5"
   integrity sha512-rHQgdo1EWfb+nPUpHe4O7i8qJPELHKNR5PAZRK+a7XxiykqOfbaAlPt5boDWAGPnYbSv0ziWZv5mq9DlFaQCxg==
@@ -186,6 +239,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansicolors@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz#665597de86a9ffe3aa9bfbe6cae5c6ea426b4979"
+  integrity sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==
+
 anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
@@ -220,6 +278,11 @@ base-x@^3.0.2:
   integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
   dependencies:
     safe-buffer "^5.0.1"
+
+base-x@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
+  integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
 
 base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
@@ -290,6 +353,13 @@ bs58@^4.0.0, bs58@^4.0.1:
   integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
   dependencies:
     base-x "^3.0.2"
+
+bs58@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
+  integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==
+  dependencies:
+    base-x "^4.0.0"
 
 buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.2"
@@ -412,7 +482,7 @@ debug@4.3.3:
   dependencies:
     ms "2.1.2"
 
-debug@^4.1.0:
+debug@^4.1.0, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==


### PR DESCRIPTION
Makes `mpl-token-metadata` compatible with additional accounts request Transfer spec.

Edit: 
- ~missing test for when `pNFT` auth rules is non-null 🤔~ Fixed by cloning in `eBJLFYPxJmMGKuFwpDWkzxZeUrad92kZRC5BJLpzyT9`
- need to finish pass-through tfer for `token-metadata`